### PR TITLE
Attempt at fixing the join problem

### DIFF
--- a/src/twitch.py
+++ b/src/twitch.py
@@ -30,7 +30,7 @@ async def initial_join():
         lst = list(channels.keys())[i: i + 10]
         print(lst)
         await twitchBot.join_channels(lst)
-        time.sleep(40)
+        await asyncio.sleep(40)
 
 @twitchBot.event
 async def event_ready():

--- a/src/twitch.py
+++ b/src/twitch.py
@@ -22,6 +22,8 @@ twitchBot = commands.Bot(
     initial_channels=['liihs']
 )
 
+twitchBot.loaded = False
+
 async def initial_join():
 # Join 10 channels at a time so the bot doesn't get rate limited on joins
     for i in range(0, len(list(channels.keys())), 10):
@@ -32,8 +34,10 @@ async def initial_join():
 
 @twitchBot.event
 async def event_ready():
-    print('ready')
-    await initial_join()
+    if not twitchBot.loaded:
+        print('ready')
+        twitchBot.loaded = True
+        await initial_join()
 
 def parseArgs(ctx):
     default = channels[ctx.channel.name]


### PR DESCRIPTION
I think the issue with the join rate limit is that the event_ready function may run multiple times.
So I added a check to see if the bot already loaded once.
Also changed sleep to asyncio.sleep to better support concurrency.
I did not test this since I couldn't get the docker and other stuff to run.
I hope this is able to fix :)