### PR TITLE
Add Top16 discord bot feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,24 +35,7 @@ pre-commit install
 
 # Testing
 
-This branch uses a local download of the dynamodb-local and an in memory database to make tests run much more quickly
-
-## Requirements
-
-- java
-  - `brew install java` on a mac
-- unzip
-- curl
-
-## Setup
-
-1. download using `./scripts/download-dynamodb-local.sh`
-2. run using `./scripts/run-dynamodb-local.sh dynamodb-local`
-3. open a 2nd terminal
-
-## Run Tests
-
-`pipenv run python testFile.py`
+We have unit tests. Instructions for running them locally can be found [here](./test). Tests are also run in CI.
 
 ## Troubleshooting
 

--- a/src/discordBot.py
+++ b/src/discordBot.py
@@ -336,16 +336,21 @@ async def send_top16_daily_recap():
 
     discord_payload = ""
 
-    def append_to_discord_payload(string):
-        discord_payload += string
-        discord_payload += "\n"
+    def append_to_discord_payload(string, payload):
+        payload += string
+        payload += "\n"
+        return payload
 
     for region in top16_players_in_each_region.keys():
-        append_to_discord_payload(f"**{region} Top 16 **")
+        discord_payload = append_to_discord_payload(
+            f"**{region} Top 16 **", discord_payload
+        )
         for rank, rating, player in top16_players_in_each_region[region]:
-            append_to_discord_payload(f"{rank}. **{player}** with **{rating}** MMR.")
+            discord_payload = append_to_discord_payload(
+                f"{rank}. **{player}** with **{rating}** MMR.", discord_payload
+            )
         # Add a linebreak after each top 16.
-        append_to_discord_payload("")
+        discord_payload += "\n"
 
     embed = discord.Embed(
         title=f"Daily Top 16 Leaderboards @ {get_pst_time()}",

--- a/src/discordBot.py
+++ b/src/discordBot.py
@@ -327,8 +327,29 @@ async def sendDailyRecap():
     recap = await dedicated_channel.send(embed=embed)
     await recap.pin()
 
+aiocron.crontab('59 7 * * *')
+async def send_top16_daily_recap():
+    top16_players_in_each_region = leaderboardBot.get_leaderboard_range(1,16)
 
-@aiocron.crontab("10 * * * *")  ## Every hour check for new buddies
+    discord_payload = ""
+
+    def append_to_discord_payload(string):
+        discord_payload += string
+        discord_payload += "\n"
+    for region in top16_players_in_each_region.keys():
+        append_to_discord_payload(f"**{region} Top 16 **")
+        for rank,player in top16_players_in_each_region[region]:
+            append_to_discord_payload(f"{rank}. **{player}**")
+        # Add a linebreak after each top 16.
+        append_to_discord_payload("")
+
+    embed = discord.Embed(title=f'Daily Top 16 Leaderboards @ {get_pst_time()}', description=discord_payload)
+
+    dedicated_channel = bot.get_channel(channelIds['wall_lii'])
+    recap = await dedicated_channel.send(embed=embed)
+    await recap.pin()
+
+@aiocron.crontab('10 * * * *') ## Every hour check for new buddies
 async def check_for_new_buddies():
     global buddyDict
     temp_dict = get_buddy_dict()

--- a/src/discordBot.py
+++ b/src/discordBot.py
@@ -328,9 +328,7 @@ async def sendDailyRecap():
     await recap.pin()
 
 
-aiocron.crontab("59 7 * * *")
-
-
+@aiocron.crontab("59 7 * * *")
 async def send_top16_daily_recap():
     top16_players_in_each_region = leaderboardBot.get_leaderboard_range(1, 16)
 
@@ -373,6 +371,7 @@ async def check_for_new_buddies():
 
 @bot.command()
 async def test(ctx):
+
     climbers = leaderboardBot.getMostMMRChanged(5, True)
     losers = leaderboardBot.getMostMMRChanged(5, False)
     hardcore_gamers = leaderboardBot.getHardcoreGamers(5)

--- a/src/discordBot.py
+++ b/src/discordBot.py
@@ -327,29 +327,37 @@ async def sendDailyRecap():
     recap = await dedicated_channel.send(embed=embed)
     await recap.pin()
 
-aiocron.crontab('59 7 * * *')
+
+aiocron.crontab("59 7 * * *")
+
+
 async def send_top16_daily_recap():
-    top16_players_in_each_region = leaderboardBot.get_leaderboard_range(1,16)
+    top16_players_in_each_region = leaderboardBot.get_leaderboard_range(1, 16)
 
     discord_payload = ""
 
     def append_to_discord_payload(string):
         discord_payload += string
         discord_payload += "\n"
+
     for region in top16_players_in_each_region.keys():
         append_to_discord_payload(f"**{region} Top 16 **")
-        for rank,player in top16_players_in_each_region[region]:
-            append_to_discord_payload(f"{rank}. **{player}**")
+        for rank, rating, player in top16_players_in_each_region[region]:
+            append_to_discord_payload(f"{rank}. **{player}** with **{rating}** MMR.")
         # Add a linebreak after each top 16.
         append_to_discord_payload("")
 
-    embed = discord.Embed(title=f'Daily Top 16 Leaderboards @ {get_pst_time()}', description=discord_payload)
+    embed = discord.Embed(
+        title=f"Daily Top 16 Leaderboards @ {get_pst_time()}",
+        description=discord_payload,
+    )
 
-    dedicated_channel = bot.get_channel(channelIds['wall_lii'])
+    dedicated_channel = bot.get_channel(channelIds["wall_lii"])
     recap = await dedicated_channel.send(embed=embed)
     await recap.pin()
 
-@aiocron.crontab('10 * * * *') ## Every hour check for new buddies
+
+@aiocron.crontab("10 * * * *")  ## Every hour check for new buddies
 async def check_for_new_buddies():
     global buddyDict
     temp_dict = get_buddy_dict()

--- a/src/leaderboardBot.py
+++ b/src/leaderboardBot.py
@@ -201,29 +201,31 @@ class LeaderBoardBot:
         return dict
 
     def get_leaderboard_range(self, start_rank, end_rank):
-        '''
-          Given a start_rank and end_rank, for each region, return a list of players in descending order between those ranks, inclusive.
-        '''
+        """
+        Given a start_rank and end_rank, for each region, return a list of players in descending order between those ranks, inclusive.
+        """
         if start_rank > end_rank:
-            raise ValueError(f"start_rank:{start_rank} must be greater than or equal to end_rank:{end_rank}")
+            raise ValueError(
+                f"start_rank:{start_rank} must be greater than or equal to end_rank:{end_rank}"
+            )
 
         # Scan the whole database, filter for players whose rank is between our desired ranks.
         # We don't have any partition keys or secondary indexes on the database, so we must scan.
         response = self.table.scan(
-            FilterExpression=Attr('Rank').between(start_rank,end_rank),
+            FilterExpression=Attr("Rank").between(start_rank, end_rank),
         )
 
         dict = {}
         # Make a list for each region, add players of that region to the list.
-        for item in response['Items']:
-            region = item['Region']
+        for item in response["Items"]:
+            region = item["Region"]
             if region not in dict:
                 dict[region] = []
-            
-            rating = item['Ratings'][-1]
+            rank = item["Rank"]
+            rating = item["Ratings"][-1]
             player_name = item["PlayerName"]
-            dict[region].append((rating,player_name))
-        
+            dict[region].append((rank, rating, player_name))
+
         # Sort each region list by player's rank.
         for key in dict.keys():
             # When sorting a list of tuples, the default behavior is to use the first element of the tuples.
@@ -231,7 +233,6 @@ class LeaderBoardBot:
             dict[key].sort()
 
         return dict
-
 
     def getMostMMRChanged(self, num, highest):
         # For each entry in the leaderboard, get the tag, region and mmr change

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,28 @@
+# Tests
+
+## Testing Locally
+
+This branch uses a local download of the dynamodb-local and an in memory database to make tests run quickly.
+
+The tests are run against static leaderboard data from a [past season](https://playhearthstone.com/en-us/community/leaderboards/?region=US&leaderboardId=BG&seasonId=1).
+
+### Requirements
+
+- java
+  - `brew install java` on a mac
+- unzip
+- curl
+
+### Setup
+
+1. download using `./scripts/download-dynamodb-local.sh`
+2. run using `./scripts/run-dynamodb-local.sh dynamodb-local`
+3. open a 2nd terminal
+
+### Run Tests
+
+```
+pipenv install
+cd test
+pipenv run python testFile.py
+```

--- a/test/testLeaderboard.py
+++ b/test/testLeaderboard.py
@@ -197,10 +197,28 @@ class testLeaderboardGet(unittest.TestCase):
         new = self.bot.getNewChannels()
         self.assertEqual(0, len(new))
 
+    def test_get_top16(self):
+        top_16_data = self.bot.get_leaderboard_range(1, 16)
+        for region in top_16_data.keys():
+            assert len(top_16_data[region]) == 16
+            player_name_set = set()
+            rank_counter = 1
+            previous_rating = float("inf")
+            for rank, rating, name in top_16_data[region]:
+                # Assert that all players in top 16 are unique.
+                assert name not in player_name_set
+                player_name_set.add(name)
+                # Assert that ranks are descending 1->16
+                assert rank == rank_counter
+                rank_counter += 1
+                # Assert that ratings are in descending order.
+                assert rating <= previous_rating
+                previous_rating = rating
+
 
 if __name__ == "__main__":
     print(f"testing leaderboardBot")
-    from dotenv import dotenv_values, load_dotenv
+    from dotenv import load_dotenv, dotenv_values
 
     load_dotenv(".test-env")
     unittest.main()

--- a/test/testLeaderboard.py
+++ b/test/testLeaderboard.py
@@ -218,7 +218,7 @@ class testLeaderboardGet(unittest.TestCase):
 
 if __name__ == "__main__":
     print(f"testing leaderboardBot")
-    from dotenv import load_dotenv, dotenv_values
+    from dotenv import dotenv_values, load_dotenv
 
     load_dotenv(".test-env")
     unittest.main()


### PR DESCRIPTION
As discussed over discord, there is essentially no way to test this. 

Ideally we could test this by having it send to a private channel for bot command development.
In the future, I think having a discord API token that is scoped to only talk to a development channel and sharing that with contributors might be a reasonable model for testing these things.

- Add get_leaderboard_range to leaderboardBot.py to get players within a certain rank range
- Add send_top16_daily_recap to discordBot.py
