### PR TITLE
Fixing an alias and a real leaderboards name being the same [leaderboards name has priority]

### DIFF
--- a/src/leaderboardBot.py
+++ b/src/leaderboardBot.py
@@ -95,14 +95,15 @@ class LeaderBoardBot:
 
         tag = self.getFormattedTag(tag)
 
-        ## check if tag has an alias:
-        if tag in self.alias:
-            tag = self.alias[tag]
-
         table = self.yesterday_table if yesterday else self.table
 
         ## check if tag on leaderboard
         player_data = self.getPlayerData(tag, table, region)
+
+        ## check if tag has an alias since no data was found
+        if len(player_data) == 0 and tag in self.alias:
+            tag = self.alias[tag]
+            player_data = self.getPlayerData(tag, table, region)
 
         if len(player_data) > 0:
             return tag, region, player_data, ""


### PR DESCRIPTION
For aliases, an alias shouldn't be able to use an alias for a name that actually exists on the leaderboard. In this case Ethan is a player so MrIncreadible shouldn't be able to use ethan as an alias going forward